### PR TITLE
Small typos fixes andy.scss

### DIFF
--- a/andy.scss
+++ b/andy.scss
@@ -214,12 +214,12 @@ Mixins availables:
 
 // usage example: @include mquery(350px, 2) { width: 100%; }
 
-@mixin mquery($width, $ratio) {
+/*@mixin mquery($width, $ratio) {
   @media only screen and (max-width: $width) and  (min--moz-device-pixel-ratio: $ratio),
   @media only screen and (max-width: $width) and  (-webkit-min-device-pixel-ratio: $ratio), {
     @content;
   }
-}
+}*/
 
 @mixin mquery-w($width) {
   @media only screen and (max-width: $width) {
@@ -227,12 +227,12 @@ Mixins availables:
   }
 }
 
-@mixin mquery-r($ratio)
+/*@mixin mquery-r($ratio)
  @media only screen and (-webkit-min-device-pixel-ratio: $ratio),
  @media only screen and (min--moz-device-pixel-ratio: $ratio) {
     @content;
   }
-}
+}*/
 
 /* OPACITY */
 


### PR DESCRIPTION
Small typo fix that was generating a error from grunt-contrib-sass

There are also some problems with these two mixins: line 230 and 217.
grunt-contrib-sass gives me this error: Syntax error: Invalid CSS after "...query-r($ratio)": expected "{", was "@media only scr..."
