### PR TITLE
Changes @mixin fontsize

### DIFF
--- a/andy.scss
+++ b/andy.scss
@@ -161,8 +161,9 @@ Mixins availables:
 // usage example: @include fontsize(16px);
 
 @mixin fontsize($size) {
+  $base-font-size: 16px !default;
   font-size: $size;
-  font-size: ($size / 16px) * 1rem;
+  font-size: ($size / $base-font-size) * 1rem;
 }
 
 /* HARDWARE ACCELERATION */


### PR DESCRIPTION
Accounts for non-16px root font sizes — 16px isn’t a universal user agent style. Avoids situations where the pixel font size calculations don't have the same result as the REM font size calculations. Can be changed from 16px default by defining $base-font-size anywhere.

Reasoning on the change: afaik, no other mixin in Andy would need to be edited on-the-fly in order to work as intended for certain use cases.
