### PR TITLE
Backwards-compatible tweaks

### DIFF
--- a/andy.scss
+++ b/andy.scss
@@ -125,7 +125,6 @@ $base-font-size: 16px !default;
 // usage example: @include box-sizing(border-box);
 
 @mixin box-sizing($type) {
-  -webkit-box-sizing:$type;
   -moz-box-sizing:$type;
   box-sizing:$type;
 }

--- a/andy.scss
+++ b/andy.scss
@@ -228,8 +228,6 @@ $base-font-size: 16px !default;
 
 @mixin hover($time, $timing-function: ease-in-out) {
   -webkit-transition: all $time $timing-function;
-  -o-transition: all $time $timing-function;
-  -moz-transition: all $time $timing-function;
   transition: all $time $timing-function;
 }
 

--- a/andy.scss
+++ b/andy.scss
@@ -163,9 +163,9 @@ $base-font-size: 16px !default;
 @mixin center-h--unk {
   position: relative;
   top: 50%;
-  -webkit-transform: translate-y(-50%);
-  -ms-transform: translate-y(-50%);
-  transform: translate-y(-50%);
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
 }
 
 /* CLEARFIX */
@@ -375,19 +375,19 @@ $base-font-size: 16px !default;
 /* TRANSLATE X */
 
 @mixin translate-x($value) {
-  -webkit-transform: translate-x($value);
-  -ms-transform: translate-x($value);
-  -o-transform: translate-x($value);
-  transform: translate-x($value);
+  -webkit-transform: translateX($value);
+  -ms-transform: translateX($value);
+  -o-transform: translateX($value);
+  transform: translateX($value);
 }
 
 /* TRANSLATE Y */
 
 @mixin translate-y($value) {
-  -webkit-transform: translate-y($value);
-  -ms-transform: translate-y($value);
-  -o-transform: translate-y($value);
-  transform: translate-y($value);
+  -webkit-transform: translateY($value);
+  -ms-transform: translateY($value);
+  -o-transform: translateY($value);
+  transform: translateY$value);
 }
 
 /* TRANSITION SCALE-DOWN */

--- a/andy.scss
+++ b/andy.scss
@@ -254,8 +254,8 @@ $base-font-size: 16px !default;
 // usage example: @include line-height(16);
 
 @mixin line-height($heightValue: 12){
-    line-height: $heightValue + px; //fallback for old browsers
-    line-height: ( 1 / ( $base-font-size / ($base-font-size * 0 + 1) ) * $heightValue + rem );
+    line-height: $heightValue * 1px; //fallback for old browsers
+    line-height: ( 1 / ( $base-font-size / ($base-font-size * 0 + 1) ) * $heightValue * 1rem );
 }
 
 /* MEDIA QUERIES */

--- a/andy.scss
+++ b/andy.scss
@@ -384,7 +384,7 @@ $base-font-size: 16px !default;
   -webkit-transform: translateY($value);
   -ms-transform: translateY($value);
   -o-transform: translateY($value);
-  transform: translateY$value);
+  transform: translateY($value);
 }
 
 /* TRANSITION SCALE-DOWN */


### PR DESCRIPTION
Takes care of a few minor issues; besides the output changing from stringified "10px" to the actual unit '10px' from `@mixin line-height`, these changes should all be non-deprecating / should not alter the output in any non-backwards-compatible ways.