### PR TITLE
Changed center-both to off set from right

### DIFF
--- a/andy.scss
+++ b/andy.scss
@@ -194,16 +194,16 @@ $base-font-size: 16px !default;
 ///   .foo {
 ///     position: absolute;
 ///     top: 50%;
-///     left: 50%;
-///     -webkit-transform: translate(-50%, -50%);
-///     -ms-transform: translate(-50%, -50%);
-///     transform: translate(-50%, -50%);
+///     right: 50%;
+///     -webkit-transform: translate(50%, -50%);
+///     -ms-transform: translate(50%, -50%);
+///     transform: translate(50%, -50%);
 ///   }
 @mixin center-both {
     position: absolute;
     top: 50%;
-    left: 50%;
-    @include prefix(transform, translate(-50%, -50%), 'webkit' 'ms');
+    right: 50%;
+    @include prefix(transform, translate(50%, -50%), 'webkit' 'ms');
 }
 
 


### PR DESCRIPTION
Changed center-both to off set from right  …
Offsetting from left can cause horizontal scroll bars to appear in IE
See http://stackoverflow.com/questions/27990347/ie-showing-horizontal-scrollbar-after-dom-element-transformed
